### PR TITLE
docs(concepts): add explanations for Refractions, Lenses, and Optics

### DIFF
--- a/docs/concepts/ lenses.md
+++ b/docs/concepts/ lenses.md
@@ -3,6 +3,39 @@ id: lenses
 ---
 # Lenses
 
-This is a placeholder for the **Lenses** concept.
+## What are Lenses?
 
-Content coming soon…
+*Lenses* help you “zoom in” on a specific part of a bigger structure, without disturbing the rest.
+
+## Benefits of Lenses
+
+- **Reusability:** Lenses make manipulating nested state (like user profiles) feel simple, no need to rewrite the whole state object.
+- **Modularity:** Lenses help you modularize access to deeply nested data, making code cleaner and more scalable.
+
+---
+
+## Example: Lens in Action
+
+```js
+const user = { profile: { name: "Alex", age: 25 }, active: true };
+
+const nameLens = {
+  get: obj => obj.profile.name,
+  set: (obj, val) => ({
+    ...obj,
+    profile: { ...obj.profile, name: val },
+  }),
+};
+
+console.log(nameLens.get(user)); // Alex
+console.log(nameLens.set(user, "Jordan"));
+// { profile: { name: "Jordan", age: 25 }, active: true }
+```
+
+In the above example, the function `nameLens` returns the name of the user's profile and sets the name of the user's profile.
+
+---
+
+## How it connects to Refract
+
+In Refract, lenses are the tool needed to manage nested component state cleanly. They let help you focus on what needs to be fixed, making the components simpler to build and maintain.

--- a/docs/concepts/optics.md
+++ b/docs/concepts/optics.md
@@ -3,6 +3,37 @@ id: optics
 ---
 # Optics
 
-This is a placeholder for the **Optics** concept.
+## What are Optics?
 
-Content coming soon…
+*Optics* help you “zoom in” on a specific part of a bigger structure, without disturbing the rest.
+
+## Benefits of Optics
+
+- **Efficiency:** Optics make manipulating nested state (like user profiles) feel simple—no need to rewrite the whole state object.
+- **Modularity:** Optics help you modularize access to deeply nested data, making code cleaner and more scalable.
+
+---
+
+## Example: Optic in Action
+
+```js
+const ageLens = {
+  get: obj => obj.profile.age,
+  set: (obj, val) => ({
+    ...obj,
+    profile: { ...obj.profile, age: val },
+  }),
+};
+
+const user = { profile: { name: "Alex", age: 25 }, active: true };
+const updated = ageLens.set(user, 26);
+console.log(updated.profile.age); // 26
+```
+
+In the above example, the `ageLens` function is an optic that returns the age of a user, making it easier to access and modify the age property.
+
+---
+
+## How it Connects to Refract
+
+Optics form the backbone of Refract’s reactive state management. Build and combine them to shape how your UI responds—smoothly composable, and perfectly maintainable.

--- a/docs/concepts/refractions.md
+++ b/docs/concepts/refractions.md
@@ -3,6 +3,33 @@ id: refractions
 ---
 # Refractions
 
-This is a placeholder for the **Refractions** concept.
+## What are Refractions?
 
-Content coming soon…
+A *refraction* is how light bends when passing through different materials. In Refract, it represents how **state shifts direction** into UI output in a smooth, predictable way.
+
+## Benefits of Refractions
+
+- **Simplicity:** Refractions show how simple state changes—like toggling themes—become visible UI responses in an intuitive, step-by-step way.
+- **Scalability:** Refractions standardize component behavior, making state transitions easier to reason about in scalable applications.
+
+---
+
+## Example: Refraction in Action
+
+```js
+let state = { theme: "light" };
+
+function refract(state) {
+  return state.theme === "light" ? "🌞" : "🌙";
+}
+
+console.log(refract(state)); // 🌞
+```
+
+In the above example, the `refract` function is a simple refraction that returns the opposite of the current theme
+
+---
+
+## How it connects to Refract
+
+Refract replaces manual functions with the `useRefraction()` hook. Think of it as the official “state bending” tool: predictable, reactive, and cleanly integrated into components.


### PR DESCRIPTION
Replaced placeholder text in the concepts section with beginner and advanced-friendly explanations. Each concept now includes:
- A plain-language metaphor (light bending, zoom lens, optics lab)
- A simple JavaScript analogy for clarity
- Context on how the concept applies in Refract

This information makes it accessible for newcomers while also giving experienced developers a deeper understanding of how Refract models state and UI flows.